### PR TITLE
Add alternate install instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ Syntax highlighting for the [Zig programming language](http://ziglang.org) in Em
 
 ## Installation
 Simply install the `zig-mode` package via [MELPA](https://melpa.org/#/getting-started).
+
+Alternatively, you can `git clone` the `zig-mode` repository somewhere
+(e.g. under your `~/.emacs.d/`), then add the following to your `.emacs` file:
+
+```elisp
+(add-to-list 'load-path "~/path/to/your/zig-mode/")
+(autoload 'zig-mode "zig-mode" nil t)
+(add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode))
+```


### PR DESCRIPTION
This provides another install option for users (such as myself) who aren't used to using MELPA, or who want to use the bleeding edge of the git repo.