### PR TITLE
fix multiline string properties rules regex

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -265,7 +265,9 @@
   (funcall
    (syntax-propertize-rules
     ;; Multiline strings
-    ("\\(\\\\\\)\\\\"
+    ;; Do not match backslashes that are preceded by single or
+    ;; double-quotes.
+    ("[^\\'\"]c?\\(\\\\\\)\\\\"
      (1 (prog1 "|"
 	  (goto-char (match-end 0))
 	  (zig-syntax-propertize-to-newline-if-in-multiline-str end)))))


### PR DESCRIPTION
Includes a negative match in the regex that excludes backslashes that
are preceded by single or double-quotes

Close: #15 