### PR TITLE
replace stdcallcc and nakedcc with callconv

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -64,7 +64,7 @@
   '(
     ;; Storage
     "const" "var" "extern" "packed" "export" "pub" "noalias" "inline"
-    "noinline" "comptime" "nakedcc" "stdcallcc" "volatile" "allowzero"
+    "noinline" "comptime" "callconv" "volatile" "allowzero"
     "align" "linksection" "threadlocal"
 
     ;; Structure


### PR DESCRIPTION
Mirror change from zig.vim:

https://github.com/ziglang/zig.vim/commit/6c6871777c980f45fff44e95d3640c3d50b469bf