### PR TITLE
Add previous-line doc comments

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -376,7 +376,7 @@ If given a SOURCE, execute the CMD on it."
           'font-lock-string-face))
     (save-excursion
       (goto-char (nth 8 state))
-      (if (looking-at "///[^/]")
+      (if (looking-at "//[/|!][^/]")
           'font-lock-doc-face
         'font-lock-comment-face))))
 


### PR DESCRIPTION
This pull request makes the plugin recognize previous-line documentation comments. Previously it only supported normal doc comments.

This isn't mentioned in the Zig documentation, but it is used several times in the Zig standard library, such as `std.log`.