### PR TITLE
fix test regression

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -397,9 +397,10 @@ If given a SOURCE, execute the CMD on it."
 ;;; Guarantee filesystem unix line endings
 (defun zig-file-coding-system ()
   (with-current-buffer (current-buffer)
-    (if (string-match "\\.d?zig\\'" buffer-file-name)
-        (setq buffer-file-coding-system 'utf-8-unix)
-      nil)
+    (if (buffer-file-name)
+        (if (string-match "\\.d?zig\\'" buffer-file-name)
+            (setq buffer-file-coding-system 'utf-8-unix)
+          nil))
 ))
 
 (add-hook 'zig-mode-hook 'zig-file-coding-system)


### PR DESCRIPTION
Previously, running the tests with `run_tests.sh` failed because `(buffer-file-name)` returns `nil` in temporary buffers which are used when testing.

Could we create a GitHub Actions/Travis/AppVeyor/... job for this repo so that this doesn't happen in future? The AppVeyor badge in the README.md refers to another repo.