### PR TITLE
Remove `this` constant

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -213,7 +213,7 @@ If given a SOURCE, execute the CMD on it."
     "true" "false"
 
     ;; Other constants
-    "null" "undefined" "this"))
+    "null" "undefined"))
 
 (defconst zig-electric-indent-chars
   '(?\; ?, ?\) ?\] ?}))


### PR DESCRIPTION
As far as I am aware, zig does not have the constant `this` anymore and has instead moved to `@This()`.