### PR TITLE
Quote arguments passed to zig via the compile function

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -57,7 +57,7 @@
 If given a SOURCE, execute the CMD on it."
   (let ((cmd-args
          (if source
-             (mapconcat 'identity (cons source args) " ")
+             (mapconcat 'shell-quote-argument (cons source args) " ")
            args)))
     (compile (concat zig-zig-bin " " cmd " " cmd-args))))
 


### PR DESCRIPTION
My home directory has spaces in it (ah, Windows...) so `compile` needs its arguments quoted.