### PR TITLE
Fix zig-test-buffer flags

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -97,7 +97,7 @@ If given a SOURCE, execute the CMD on it."
 (defun zig-test-buffer ()
   "Test buffer using `zig test`."
   (interactive)
-  (zig--run-cmd "test" (buffer-file-name) "--release-fast"))
+  (zig--run-cmd "test" (buffer-file-name) "-O" "ReleaseFast"))
 
 ;;;###autoload
 (defun zig-run ()


### PR DESCRIPTION
It would be great to check for previous versions of ziglang and use `--fast-release` flag for them, but I'm not sure about the need of their support as long as zig's major version is still 0, so I'll put a PR just in case.

Ref: #40