### PR TITLE
Use read-only-mode instead of toggle-read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run all unit tests with `emacs`, run:
 ./run_tests.sh
 ```
 
-Note that Emacs 24 or later is required.  If you need to specify which Emacs
+Note that Emacs 24.3 or later is required.  If you need to specify which Emacs
 binary to use, you can do that by setting the `EMACS` environment variable,
 e.g.:
 

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -443,9 +443,9 @@ If given a SOURCE, execute the CMD on it."
 	(zig-format-buffer)))
 
 (defun colorize-compilation-buffer ()
-  (toggle-read-only)
+  (read-only-mode)
   (ansi-color-apply-on-region compilation-filter-start (point))
-  (toggle-read-only))
+  (read-only-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode))

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -443,9 +443,9 @@ If given a SOURCE, execute the CMD on it."
 	(zig-format-buffer)))
 
 (defun colorize-compilation-buffer ()
-  (read-only-mode)
+  (read-only-mode 0)
   (ansi-color-apply-on-region compilation-filter-start (point))
-  (read-only-mode))
+  (read-only-mode 1))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode))


### PR DESCRIPTION
`toggle-read-only` was declared obsolete in emacs 24.3

I also updated the recommended emacs version in the README. Let me know if this is desired or not.

The change fixes the related compiler warning:

```
In colorize-compilation-buffer:
zig-mode.el:448:4:Warning: ‘toggle-read-only’ is an obsolete function (as of
    24.3); use ‘read-only-mode’ instead.
zig-mode.el:449:31:Warning: ‘toggle-read-only’ is an obsolete function (as of
    24.3); use ‘read-only-mode’ instead.
```