### PR TITLE
Switch formatting to reformatter.el

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,4 +6,17 @@ else
     echo "Running with EMACS=${EMACS}"
 fi
 
-${EMACS} --batch -l zig-mode.el -l tests.el -f ert-run-tests-batch-and-exit
+# From https://github.com/jcollard/elm-mode/blob/master/Makefile
+NEEDED_PACKAGES="reformatter"
+INIT_PACKAGES="(progn \
+  (require 'package) \
+  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
+  (package-initialize) \
+  (dolist (pkg '(${NEEDED_PACKAGES})) \
+    (unless (package-installed-p pkg) \
+      (unless (assoc pkg package-archive-contents) \
+        (package-refresh-contents)) \
+      (package-install pkg))) \
+  )"
+
+${EMACS} --eval "${INIT_PACKAGES}" --batch -l zig-mode.el -l tests.el -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
See #39 for the corresponding issue.

This changes some of the weird behavior which arises from using `revert-buffer` after formatting such as #49.

Of course, this massively changes formatting behavior for users used to the formatting functionality. For example, formatting on save is now handled by a new minor mode instead of a `defcustom` and a toggle function. This also adds a dependency on the `reformatter` package in MELPA.

Closes #39
Closes #61 
Closes #49