### PR TITLE
Implement beginning/end-of-defun

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -309,8 +309,8 @@ at the beginning of the defun body.
 
 This is written mainly to be used as `end-of-defun-function' for Zig."
   (interactive)
-  ;; Jump over the function parameters, if they exist.
-  (if (re-search-forward "(" (point-at-eol) t)
+  ;; Jump over the function parameters and paren-wrapped return, if they exist.
+  (while (re-search-forward "(" (point-at-eol) t)
       (progn
         (backward-char)
         (forward-sexp)))

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -269,8 +269,7 @@ If given a SOURCE, execute the CMD on it."
   (concat "^"
           (regexp-opt
            '("const" "pub" "fn" "extern" "export" "test"))
-          "[[:space:]]+"
-          ".*{")
+          "[[:space:]]+")
   "Start of a Zig item.")
 
 (defun zig-beginning-of-defun (&optional arg)

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -326,8 +326,6 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
         (condition-case nil
             (forward-sexp)
           (scan-error
-           ;; The parentheses are unbalanced; instead of being unable
-           ;; to fontify, just jump to the end of the buffer
            (goto-char (point-max))))
         (end-of-line))
     ;; There is no opening brace, so consider the whole buffer to be one "defun"

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -309,6 +309,12 @@ at the beginning of the defun body.
 
 This is written mainly to be used as `end-of-defun-function' for Zig."
   (interactive)
+  ;; Jump over the function parameters, if they exist.
+  (if (re-search-forward "(" (point-at-eol) t)
+      (progn
+        (backward-char)
+        (forward-sexp)))
+
   ;; Find the opening brace
   (if (re-search-forward "[{]" nil t)
       (progn


### PR DESCRIPTION
This allows us to use C-M-a and C-M-e to navigate by function blocks.
Also includes test, const, and export blocks that contain a brace.

Credit goes to `rust-mode`, which this code was yanked and modified from.