### PR TITLE
Add `zig-test-optimization-mode` and `zig-run-optimization-mode`

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -50,6 +50,18 @@
   :safe #'stringp
   :group 'zig-mode)
 
+(defcustom zig-run-optimization-mode "Debug"
+  "Optimization mode to run code with."
+  :type 'string
+  :safe #'stringp
+  :group 'zig-mode)
+
+(defcustom zig-test-optimization-mode "Debug"
+  "Optimization mode to run tests with."
+  :type 'string
+  :safe #'stringp
+  :group 'zig-mode)
+
 ;; zig CLI commands
 
 (defun zig--run-cmd (cmd &optional source &rest args)
@@ -97,13 +109,13 @@ If given a SOURCE, execute the CMD on it."
 (defun zig-test-buffer ()
   "Test buffer using `zig test`."
   (interactive)
-  (zig--run-cmd "test" (buffer-file-name) "-O" "ReleaseFast"))
+  (zig--run-cmd "test" (buffer-file-name) "-O" zig-test-optimization-mode))
 
 ;;;###autoload
 (defun zig-run ()
   "Create an executable from the current buffer and run it immediately."
   (interactive)
-  (zig--run-cmd "run" (buffer-file-name)))
+  (zig--run-cmd "run" (buffer-file-name) "-O" zig-run-optimization-mode))
 
 ;;;###autoload
 (defun zig-format-buffer ()


### PR DESCRIPTION
These two variables allow for the `zig-run` and `zig-test-buffer` functions to run Zig with the user's desired optimization modes,
and also changes the default optimization mode to `Debug` (used to be `ReleaseFast`), since not having safety is not desirable while testing code that may potentially panic.