### PR TITLE
Fix font-lock of parameters with pointer or array types

### DIFF
--- a/tests.el
+++ b/tests.el
@@ -101,6 +101,18 @@ const python =
      ("\\\\def main():\n" zig-multiline-string-face)
      ("\\\\    print(\"Hello, world!\")\n" zig-multiline-string-face))))
 
+(ert-deftest test-font-lock-parameters-pointers-and-arrays ()
+  (zig-test-font-lock
+   "fn doSomething(thingPtr: *Thing, string: []const u8) void {}"
+   '(("fn" font-lock-keyword-face)
+     ("doSomething" font-lock-function-name-face)
+     ("thingPtr" font-lock-variable-name-face)
+     ("Thing" font-lock-type-face)
+     ("string" font-lock-variable-name-face)
+     ("const" font-lock-keyword-face)
+     ("u8" font-lock-type-face)
+     ("void" font-lock-type-face))))
+
 ;;===========================================================================;;
 ;; Indentation tests
 

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -159,7 +159,7 @@ If given a SOURCE, execute the CMD on it."
 (defconst zig-re-identifier "[[:word:]_][[:word:]_[:digit:]]*")
 (defconst zig-re-type-annotation
   (concat (zig-re-grab zig-re-identifier)
-          "[[:space:]]*:[[:space:]]*"
+          "[[:space:]]*:[[:space:]]*\\**[[:space:]]*\\(?:\\[[^]]*\\][[:space:]]*\\)?"
           (zig-re-grab zig-re-identifier)))
 
 (defun zig-re-definition (dtype)


### PR DESCRIPTION
I've been playing with zig for a bit and this has been driving me crazy:

<img width="799" alt="zig-mode-fix" src="https://user-images.githubusercontent.com/2094731/120679161-dee21980-c466-11eb-9e55-285da7e44b65.png">

Uses the special Elisp _"shy group"_ construct that I found out (also called _"non-capturing"_ or _"unnumbered group"_)

This changes the regex from:

`(identifier) (possible whitespace) (colon) (possible whitespace) (identifier)`

to:

`(identifier) (possible whitespace) (colon) (possible whitespace) (0 or more * characters) (possible whitespace) (possible [] expression with anything inside) (possible whitespace) (identifier)`