### PR TITLE
Fix font-lock of parameters with optional, pointer or array types

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -156,10 +156,18 @@ If given a SOURCE, execute the CMD on it."
   "Construct a group regular expression for INNER."
   (concat "\\(" inner "\\)"))
 
+(defconst zig-re-optional "\\(?:[[:space:]]*\\?[[:space:]]*\\)")
+(defconst zig-re-pointer "\\(?:[[:space:]]*\\*\\(?:const[[:space:]]*\\)?[[:space:]]*\\)")
+(defconst zig-re-array "\\(?:[[:space:]]*\\[[^]]*\\]\\(?:const[[:space:]]*\\)?[[:space:]]*\\)")
+
+(defconst zig-re-optionals-pointers-arrays
+  (concat "\\(?:" zig-re-optional "\\|" zig-re-pointer "\\|" zig-re-array "\\)*"))
+
 (defconst zig-re-identifier "[[:word:]_][[:word:]_[:digit:]]*")
 (defconst zig-re-type-annotation
   (concat (zig-re-grab zig-re-identifier)
           "[[:space:]]*:[[:space:]]*"
+          zig-re-optionals-pointers-arrays
           (zig-re-grab zig-re-identifier)))
 
 (defun zig-re-definition (dtype)


### PR DESCRIPTION
I've been playing with zig for a bit and this has been driving me crazy:

<img width="799" alt="zig-mode-fix" src="https://user-images.githubusercontent.com/2094731/120679161-dee21980-c466-11eb-9e55-285da7e44b65.png">

Uses the special Elisp _"shy group"_ construct that I found out (also called _"non-capturing"_ or _"unnumbered group"_)

This changes the regex from:

(identifier)
(possible whitespace)
(colon)
(possible whitespace)
(identifier)

to:

(identifier)
(possible whitespace)
(colon)
(possible whitespace)
(any number of (`*` or `* const`) OR (`[]` or `[] const` with anything inside the `[]`) OR `?`)
(possible whitespace)
(identifier)