### PR TITLE
Add optional ansi-coloration for the zig-fmt buffer

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -153,8 +153,8 @@ If given a SOURCE, execute the CMD on it."
              (when zig-format-show-buffer
                (progn
                  (pop-to-buffer fmt-buffer)
-		 (when zig-ansi-color-for-format-errors
-		   (ansi-color-apply-on-region (point-min) (point-max)))
+                 (when zig-ansi-color-for-format-errors
+                   (ansi-color-apply-on-region (point-min) (point-max)))
                  (compilation-mode)
                  (when zig-return-to-buffer-after-format
                    (pop-to-buffer file-buffer))))

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -126,6 +126,9 @@ If given a SOURCE, execute the CMD on it."
 (defvar zig-return-to-buffer-after-format nil
   "Enable zig-format-buffer to return to file buffer after fmt is done.")
 
+(defvar zig-ansi-color-for-format-errors nil
+  "Enable ansi-coloration of error output from zig fmt.")
+
 ;;;###autoload
 (defun zig-format-buffer ()
   "Format the current buffer using the zig fmt."
@@ -150,6 +153,8 @@ If given a SOURCE, execute the CMD on it."
              (when zig-format-show-buffer
                (progn
                  (pop-to-buffer fmt-buffer)
+		 (when zig-ansi-color-for-format-errors
+		   (ansi-color-apply-on-region (point-min) (point-max)))
                  (compilation-mode)
                  (when zig-return-to-buffer-after-format
                    (pop-to-buffer file-buffer))))


### PR DESCRIPTION
This PR addresses issue #64 

The fix is simply calling `ansi-color-apply-on-region` on the whole buffer.  I've hidden this behind a variable that must be set to enable it, just in case anyone is really enjoying the other way ;-) 