### PR TITLE
Add NonGNU ELPA badge and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ later.
 
 ## Installation
 
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/zig-mode.svg)](https://elpa.nongnu.org/nongnu/zig-mode.html)
 [![MELPA](https://melpa.org/packages/zig-mode-badge.svg)](https://melpa.org/#/zig-mode)
 
-Simply install the `zig-mode` package via
+Simply install the `zig-mode` package via [NonGNU ELPA](https://elpa.nongnu.org/) or
 [MELPA](https://melpa.org/#/getting-started).
 
 Alternatively, you can `git clone` the `zig-mode` repository somewhere


### PR DESCRIPTION
This adds a NonGNU ELPA badge because it looks nice and is occasionally useful. It also adds instructions for how to install from NonGNU ELPA.

Thanks!