### PR TITLE
Add `comment-start-skip`

### DIFF
--- a/tests.el
+++ b/tests.el
@@ -61,9 +61,11 @@ const string =
 // This is a normal comment\n
 /// This is a doc comment\n
 //// This is a normal comment again\n"
-   '(("// This is a normal comment\n" font-lock-comment-face)
+   '(("// " font-lock-comment-delimiter-face)
+     ("This is a normal comment\n" font-lock-comment-face)
      ("/// This is a doc comment\n" font-lock-doc-face)
-     ("//// This is a normal comment again\n" font-lock-comment-face))))
+     ("//// " font-lock-comment-delimiter-face)
+     ("This is a normal comment again\n" font-lock-comment-face))))
 
 (ert-deftest test-font-lock-decl-const ()
   (zig-test-font-lock

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -529,6 +529,7 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
 \\{zig-mode-map}"
   :group 'zig-mode
   (setq-local comment-start "// ")
+  (setq-local comment-start-skip "//+ *")
   (setq-local comment-end "")
   (setq-local electric-indent-chars
               (append zig-electric-indent-chars


### PR DESCRIPTION
#### Copy of commit msg
This fixes many builtin comment-related functions (`newcomment.el`) that depend on this variable.

This also fixes test `test-font-lock-comments` on Emacs 28:
In Emacs 28, `comment-start-skip` is assigned a default value based on `comment-start`, which results in comment delimiters (//) being fontified with `font-lock-comment-delimiter-face`.