### PR TITLE
Enable parsing std.Progress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Alternatively, you can `git clone` the `zig-mode` repository somewhere
   (add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode)))
 ```
 
+To enable parsing of Zig `std.Progress` output (which is shown during `zig build`) in compilation or shell
+buffers, add the following to your emacs config:
+```
+(zig-enable-progress-parsing)
+```
+This overrides function `ansi-color-apply-on-region` with a patched version.
+
 ## Testing
 
 [![Build status](https://ci.appveyor.com/api/projects/status/u78j130vv4l6v21t?svg=true)](https://ci.appveyor.com/project/mdsteele/zig-mode)

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -551,9 +551,8 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
 	(zig-format-buffer)))
 
 (defun colorize-compilation-buffer ()
-  (read-only-mode 0)
-  (ansi-color-apply-on-region compilation-filter-start (point))
-  (read-only-mode 1))
+  (let ((inhibit-read-only t))
+    (ansi-color-apply-on-region compilation-filter-start (point))))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode))

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -550,13 +550,15 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
   (when zig-format-on-save
 	(zig-format-buffer)))
 
-(defun colorize-compilation-buffer ()
-  (let ((inhibit-read-only t))
-    (ansi-color-apply-on-region compilation-filter-start (point))))
-
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode))
-(add-hook 'compilation-filter-hook 'colorize-compilation-buffer)
+(if (>= emacs-major-version 28)
+    (add-hook 'compilation-filter-hook 'ansi-color-compilation-filter)
+  (progn
+    (defun colorize-compilation-buffer ()
+      (let ((inhibit-read-only t))
+        (ansi-color-apply-on-region compilation-filter-start (point))))
+    (add-hook 'compilation-filter-hook 'colorize-compilation-buffer)))
 
 (provide 'zig-mode)
 ;;; zig-mode.el ends here


### PR DESCRIPTION
This PR (based on #69) enables parsing `std.Progress` output in compilation and shell buffers.
In particular, it unlocks proper parsing of progress output of `zig build/run/...` cmds.

Marked as a draft, because the implementation is a bit hacky. It requires overriding `ansi-color-apply-on-region` with a patched implementation ([here's the patch diff](https://gist.github.com/erikarvstedt/f3b8b4a866ca3a18e293abea2bea45df)).
If you're interested in merging this, I'll add an implementation for Emacs 29.

You can test this with:
```elisp
# Call this once to enable progress parsing
(zig-enable-progress-parsing)

# Run a `zig build-exe` demo command.
# Delete ~/.cache/zig to force compilation progress output.
(let ((compilation-environment '("TERM=ansi"))
      (shell-file-name "bash"))
  (compilation-start "rm -rf ~/.cache/zig && cd /tmp && echo 'pub fn main() void {}' > src.zig && zig build-exe src.zig"))
```