### PR TITLE
Restore minor-mode-list across revert-buffer Calls in zig-format-buffer

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -158,7 +158,9 @@ If given a SOURCE, execute the CMD on it."
                  (compilation-mode)
                  (when zig-return-to-buffer-after-format
                    (pop-to-buffer file-buffer))))
-           (revert-buffer :ignore-auto :noconfirm)))))))
+           (let ((active-minor-modes-list minor-mode-list))
+	     (revert-buffer :ignore-auto :noconfirm :preserve-modes)
+	     (setq minor-mode-list active-minor-modes-list))))))))
 
 (defun zig-re-word (inner)
   "Construct a regular expression for the word INNER."


### PR DESCRIPTION
zig-format-buffer calls revert-buffer which ends up terminating minor modes like lsp. By saving the minor-mode-list context and then restoring it after the revert-buffer call (along with setting the PRESERVE-MODES parameter to true within the call), we are able to retain the minor modes (like lsp) across calls to zig-format-buffer.

I believe this addresses the issue pointed out in #49. This approach was inspired by [this Github comment](https://github.com/emacs-lsp/lsp-mode/issues/3469#issuecomment-1100911400). 
