### PR TITLE
`zig-mode` changes global `compilation-filter-hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ e.g.:
 EMACS=/usr/bin/emacs24 ./run_tests.sh
 ```
 
+## Optional Configuration
+
+`zig-mode` used to enable coloration of the compilation buffer using
+ANSI color codes, but this affected *all* compilation buffers, not just
+zig compilation output.
+If you want to restore this behavior, you can add the following snippet
+to your `init.el` or `.emacs` file:
+
+```elisp
+(if (>= emacs-major-version 28)
+    (add-hook 'compilation-filter-hook 'ansi-color-compilation-filter)
+  (progn
+    (defun colorize-compilation-buffer ()
+      (let ((inhibit-read-only t))
+        (ansi-color-apply-on-region compilation-filter-start (point))))
+    (add-hook 'compilation-filter-hook 'colorize-compilation-buffer)))
+```
+
 ## License
 
 `zig-mode` is distributed under the terms of the GNU General Public License as

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -553,13 +553,6 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.zig\\'" . zig-mode))
-(if (>= emacs-major-version 28)
-    (add-hook 'compilation-filter-hook 'ansi-color-compilation-filter)
-  (progn
-    (defun colorize-compilation-buffer ()
-      (let ((inhibit-read-only t))
-        (ansi-color-apply-on-region compilation-filter-start (point))))
-    (add-hook 'compilation-filter-hook 'colorize-compilation-buffer)))
 
 (provide 'zig-mode)
 ;;; zig-mode.el ends here


### PR DESCRIPTION
I have recently re-started enjoying zig, and I am using Emacs.  I noticed that `zig-mode` adds coloring functions to the (global!) `compilation-filter-hook`.

This affects *all* compilation output, ie, all other languages, and even derived modes like `grep-mode` and many more.

Therefore, this kind of thing is usually considered overly intrusive for a major-mode.  Would you consider removing the code which does that?  I'm talking about https://github.com/ziglang/zig-mode/blob/dbc648f5bca8f3b9ca2cc7827f326f5530115144/zig-mode.el#L556 ff. at the end of the file.

If users want that, they usually already have it enabled voluntarily; a note in the documentation might alert them to the possibility.  If you feel strongly about it, one proper way to force the colorization on users would be to use an additional zig-specific compilation-mode.

