### PR TITLE
compilation

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -77,7 +77,7 @@ If given a SOURCE, execute the CMD on it."
          (if source
              (mapconcat 'shell-quote-argument (cons source args) " ")
            args)))
-    (compile (concat zig-zig-bin " " cmd " " cmd-args))))
+    (compilation-start (concat zig-zig-bin " " cmd " " cmd-args))))
 
 ;;;###autoload
 (defun zig-toggle-format-on-save ()


### PR DESCRIPTION
using 'compile' sets the compile command the next time it is invoked. This can be a bit frustrating to the end user as if they have some custom compile command it will be overwritten with whatever zig-mode is running. All tests ran with './run_tests.sh' passed and I tested it locally with zig commands I believe there is no conflict. 