### PR TITLE
Handle multi-line if expressions better

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -19,4 +19,4 @@ INIT_PACKAGES="(progn \
       (package-install pkg))) \
   )"
 
-${EMACS} --eval "${INIT_PACKAGES}" --batch -l zig-mode.el -l tests.el -f ert-run-tests-batch-and-exit
+"${EMACS}" --eval "${INIT_PACKAGES}" --batch -l zig-mode.el -l tests.el -f ert-run-tests-batch-and-exit

--- a/tests.el
+++ b/tests.el
@@ -219,7 +219,7 @@ blarg(foo,
           quux,
       quux);"))
 
-(ert-deftest test-indent-if-else ()
+(ert-deftest test-indent-if-else-statement ()
   (zig-test-indent-region
    "
 fn sign(value: i32) i32 {
@@ -238,6 +238,27 @@ fn sign(value: i32) i32 {
     } else {
         return 0;
     }
+}"))
+
+(ert-deftest test-indent-if-else-expression ()
+  (zig-test-indent-region
+   "
+fn sign(i: i32) i32 {
+return if (i == 0)
+0
+else if (i > 0)
+-1
+else
+-1;
+}"
+   "
+fn sign(i: i32) i32 {
+    return if (i == 0)
+        0
+    else if (i > 0)
+        -1
+    else
+        -1;
 }"))
 
 (ert-deftest test-indent-struct ()

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -378,7 +378,7 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
                   ;; expression from the previous line, false otherwise.
                   (is-expr-continutation
                    (and
-                    (not (looking-at "[]});]"))
+                    (not (looking-at "[]});]\\|else"))
                     (save-excursion
                       (zig-skip-backwards-past-whitespace-and-comments)
                       (when (> (point) 1)


### PR DESCRIPTION
Fixes #78

Exclude a line from being treated as a continuing expression if it starts with `else`. I'm not sure where else in the grammar this would show up so it seemed like the straightforward approach to me. I don't have much experience writing indentation functions for modes though.

Also added quotes around ${EMACS} in run_tests.sh to make it easier to run the tests on windows (my Emacs is under "C:\Program Files").