### PR TITLE
Replace obsolete function `point-at-eol` with equivalent.

### DIFF
--- a/tests.el
+++ b/tests.el
@@ -391,16 +391,6 @@ const FooBarError = enum {};
 	  "Foo"
 	  "FooBarError"))))
 
-(ert-deftest test-imenu-enum ()
-  (test-imenu
-   "
-pub const Foo = enum {};
-const FooBarError = enum {};
-"
-   '(("Enum"
-	  "Foo"
-	  "FooBarError"))))
-
 (ert-deftest test-imenu-all ()
   (test-imenu
    "

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -321,7 +321,7 @@ This is written mainly to be used as `end-of-defun-function' for Zig."
   (interactive)
 
   ;; Jump over the function parameters and paren-wrapped return, if they exist.
-  (while (re-search-forward "(" (point-at-eol) t)
+  (while (re-search-forward "(" (line-end-position) t)
     (progn
       (backward-char)
       (forward-sexp)))


### PR DESCRIPTION
Emacs 29.1+ emits a warning when code using `point-at-eol` is compiled; see emacs/master commit b7e867. This is a trivial but safe change to get rid of that warning. `point-at-eol` seems to have been the same thing as `line-end-position` since 1999 (emacs/master commit 475fb2f). I've tested this briefly and the behavior of `zig-end-of-defun` does seem to be the same with this change.