### PR TITLE
Add addrspace to keywords

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -178,7 +178,7 @@ If given a SOURCE, execute the CMD on it."
     ;; Storage
     "const" "var" "extern" "packed" "export" "pub" "noalias" "inline"
     "noinline" "comptime" "callconv" "volatile" "allowzero"
-    "align" "linksection" "threadlocal"
+    "align" "linksection" "threadlocal" "addrspace"
 
     ;; Structure
     "struct" "enum" "union" "error" "opaque"


### PR DESCRIPTION
I was experimenting with a few language features and found out that `addrspace` is not highlighted in emacs. Because it is not present in the keyword table.
Refer: https://ziglang.org/documentation/0.11.0/#Keyword-Reference
