### PR TITLE
Fix autoload cookies for reformatter commands

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -127,9 +127,9 @@ If given a SOURCE, execute the CMD on it."
   :group 'zig-mode
   :lighter " ZigFmt")
 
-;;;###autoload (autoload 'zig-format-buffer "current-file" nil t)
-;;;###autoload (autoload 'zig-format-region "current-file" nil t)
-;;;###autoload (autoload 'zig-format-on-save-mode "current-file" nil t)
+;;;###autoload (autoload 'zig-format-buffer "zig-mode" nil t)
+;;;###autoload (autoload 'zig-format-region "zig-mode" nil t)
+;;;###autoload (autoload 'zig-format-on-save-mode "zig-mode" nil t)
 
 (defun zig-re-word (inner)
   "Construct a regular expression for the word INNER."


### PR DESCRIPTION
The 'current-file' was apparently copied intact from the reformatter examples, but it means the corresponding autoloads generated at package installation time don't really work.