### PR TITLE
add `.` to `zig-re-identifier` to highlight namespaced types

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -19,4 +19,4 @@ INIT_PACKAGES="(progn \
       (package-install pkg))) \
   )"
 
-"${EMACS}" --eval "${INIT_PACKAGES}" --batch -l zig-mode.el -l tests.el -f ert-run-tests-batch-and-exit
+"${EMACS}" --eval "${INIT_PACKAGES}" --batch -l zig-mode.el -l test/zig-tests.el -f ert-run-tests-batch-and-exit

--- a/test/zig-tests.el
+++ b/test/zig-tests.el
@@ -118,6 +118,26 @@ const python =
      ("void" font-lock-type-face)
      )))
 
+(ert-deftest test-font-lock-parameters-with-periods ()
+  (zig-test-font-lock
+   "fn doSomething(arg: thing.with.periods) void {}"
+   '(("fn" font-lock-keyword-face)
+     ("doSomething" font-lock-function-name-face)
+     ("arg" font-lock-variable-name-face)
+     ("thing.with.periods" font-lock-type-face)
+     ("void" font-lock-type-face)
+     )))
+
+(ert-deftest test-font-lock-struct-type-with-periods ()
+  (zig-test-font-lock
+   "const S = struct { field: thing.with.periods }; "
+   '(("const" font-lock-keyword-face)
+     ("S" font-lock-variable-name-face)
+     ("struct" font-lock-keyword-face)
+     ("field" font-lock-variable-name-face)
+     ("thing.with.periods" font-lock-type-face)
+     )))
+
 ;; Test all permutations of '?', '*', '[]', '* const', and '[] const' for 3 of those in a row
 ;; For example, ??[]Bar or [][]const *Bar
 (ert-deftest test-font-lock-parameters-optionals-pointers-and-arrays ()

--- a/zig-mode.el
+++ b/zig-mode.el
@@ -134,11 +134,12 @@ If given a SOURCE, execute the CMD on it."
   (concat "\\(?:" zig-re-optional "\\|" zig-re-pointer "\\|" zig-re-array "\\)*"))
 
 (defconst zig-re-identifier "[[:word:]_][[:word:]_[:digit:]]*")
+(defconst zig-re-type "[[:word:]_.][[:word:]_.[:digit:]]*")
 (defconst zig-re-type-annotation
   (concat (zig-re-grab zig-re-identifier)
           "[[:space:]]*:[[:space:]]*"
           zig-re-optionals-pointers-arrays
-          (zig-re-grab zig-re-identifier)))
+          (zig-re-grab zig-re-type)))
 
 (defun zig-re-definition (dtype)
   "Construct a regular expression for definitions of type DTYPE."


### PR DESCRIPTION
This change adds `.` to the `zig-re-identifier` regex so that namespaced types are entirely highlighted using `font-lock-type-face`, instead of only highlighting the first namespace.

Before:
![before](https://github.com/ziglang/zig-mode/assets/126992142/7427cb8a-5ed0-4abf-b98d-7df3a065d83a)

After:
![after](https://github.com/ziglang/zig-mode/assets/126992142/7639ea59-6e9e-49ef-a2c3-abb669e5e546)

I tried to look at what `zig-re-identifier` is used for to make sure there wouldn't be any unintended side effects from this change, but I can't tell for sure. I skimmed some zig files and it looked like it only affected struct field types and function arguments.