### PR TITLE
Save buffers before running zig commands

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -67,6 +67,7 @@
   "Use compile command to execute a zig CMD with ARGS if given.
 If given a SOURCE, execute the CMD on it."
   (let ((cmd-args (if source (cons source args) args)))
+    (save-some-buffers)
     (compilation-start (mapconcat 'shell-quote-argument
                                   `(,zig-zig-bin ,cmd ,@cmd-args) " "))))
 


### PR DESCRIPTION
This ensures our source files are in sync before zig reads them, otherwise zig may implicitly compile out-of-date source files.

This closes #106 