### PR TITLE
Explicitly define zig-mode-hook

### DIFF
--- a/zig-mode.el
+++ b/zig-mode.el
@@ -36,6 +36,11 @@
   :link '(url-link "https://ziglang.org/")
   :group 'languages)
 
+(defcustom zig-mode-hook nil
+  "Hook called by `zig-mode'."
+  :type 'hook
+  :group 'zig-mode)
+
 (defcustom zig-indent-offset 4
   "Indent Zig code by this number of spaces."
   :type 'integer


### PR DESCRIPTION
Get zig-mode-hook to appear in the customize menu by explicitly defining it.

This closes #36